### PR TITLE
Make Time Zone Configurable for Date Filters

### DIFF
--- a/src/data/build.js
+++ b/src/data/build.js
@@ -3,5 +3,6 @@ require('dotenv').config()
 module.exports = {
   env: process.env.ELEVENTY_ENV,
   timestamp: new Date(),
+  timezone: process.env.TIMEZONE || 'UTC',
   url: process.env.URL || 'http://localhost:8080',
 }

--- a/utils/filters.js
+++ b/utils/filters.js
@@ -1,12 +1,24 @@
 const { DateTime } = require('luxon')
 
+const build = require('../src/data/build')
+
+let defaultZone = 'local';
+if (Object.prototype.hasOwnProperty.call(build, 'timezone')) {
+  const testDate = DateTime.local().setZone(build.timezone);
+  if (testDate.isValid) {
+    defaultZone = build.timezone;
+  } else {
+    console.warn(testDate.invalidExplanation);
+  }
+}
+
 module.exports = {
-  dateToFormat: function (date, format) {
-    return DateTime.fromJSDate(date, { zone: 'utc' }).toFormat(String(format))
+  dateToFormat: function (date, format, zone = defaultZone) {
+    return DateTime.fromJSDate(date, { zone }).toFormat(String(format))
   },
 
-  dateToISO: function (date) {
-    return DateTime.fromJSDate(date, { zone: 'utc' }).toISO({
+  dateToISO: function (date, zone = defaultZone) {
+    return DateTime.fromJSDate(date, { zone }).toISO({
       includeOffset: false,
       suppressMilliseconds: true,
     })


### PR DESCRIPTION
This PR introduces 2 features related to the `dateToFormat` and `dateToISO` filters:

1. The site can have a default time zone configured
2. The filters themselves take an (optional) additional parameter to specify the time zone

The default time zone can be configured via a new (optional) `TIMEZONE` environmental variable, or it can be set in the `data/build.js` file. The time zone still defaults to UTC (via the `data/build.js` file), so this will only impact users who manually change the default time zone.

Additionally, a warning is output if an invalid time zone is specified (for the default time zone configuration), and the local time zone is used instead. I made the assumption that if a user is specifying (or trying to specify) a timezone, they intentionally don't want UTC, so local seemed like a safe bet.